### PR TITLE
Fix windows compilation (Closes #3)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -38,6 +38,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: test
+          args: -- --show-output
 
   fmt:
     name: Rustfmt

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2018"
 libc = "0.2"
 
 [target.'cfg(target_os = "windows")'.dependencies]
-winapi = "0.3"
+winapi = { version = "0.3", features = ["minwindef", "winerror", "ws2def", "ws2ipdef"] }
 
 [target.'cfg(target_os = "android")'.dependencies.if-addrs-sys]
 version = "0.2"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,6 @@
     stable_features,
     unconditional_recursion,
     unknown_lints,
-    unsafe_code,
     unused,
     unused_allocation,
     unused_attributes,

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -13,8 +13,8 @@ use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 use std::ptr::NonNull;
 #[cfg(windows)]
 use winapi::{
-    shared::ws2ipdef::SOCKADDR_IN6 as sockaddr_in6,
     shared::ws2def::{AF_INET, AF_INET6, SOCKADDR as sockaddr, SOCKADDR_IN as sockaddr_in},
+    shared::ws2ipdef::SOCKADDR_IN6 as sockaddr_in6,
 };
 
 pub fn to_ipaddr(sockaddr: *const sockaddr) -> Option<IpAddr> {

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -14,7 +14,7 @@ use std::ptr::NonNull;
 #[cfg(windows)]
 use winapi::{
     shared::ws2ipdef::SOCKADDR_IN6 as sockaddr_in6,
-    winapi::shared::ws2def::{AF_INET, AF_INET, SOCKADDR as sockaddr, SOCKADDR_IN as sockaddr_in},
+    shared::ws2def::{AF_INET, AF_INET6, SOCKADDR as sockaddr, SOCKADDR_IN as sockaddr_in},
 };
 
 pub fn to_ipaddr(sockaddr: *const sockaddr) -> Option<IpAddr> {

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -59,23 +59,25 @@ impl SockAddr {
     fn as_ipaddr(&self) -> Option<IpAddr> {
         match self.sockaddr_in() {
             Some(SockAddrIn::In(sa)) => {
+                let s_addr = unsafe { sa.sin_addr.S_un.S_addr() };
                 // Ignore all 169.254.x.x addresses as these are not active interfaces
-                if sa.sin_addr.S_un & 65535 == 0xfea9 {
+                if s_addr & 65535 == 0xfea9 {
                     return None;
                 }
                 Some(IpAddr::V4(Ipv4Addr::new(
-                    ((sa.sin_addr.S_un >> 0) & 255) as u8,
-                    ((sa.sin_addr.S_un >> 8) & 255) as u8,
-                    ((sa.sin_addr.S_un >> 16) & 255) as u8,
-                    ((sa.sin_addr.S_un >> 24) & 255) as u8,
+                    ((s_addr >> 0) & 255) as u8,
+                    ((s_addr >> 8) & 255) as u8,
+                    ((s_addr >> 16) & 255) as u8,
+                    ((s_addr >> 24) & 255) as u8,
                 )))
             }
             Some(SockAddrIn::In6(sa)) => {
+                let s6_addr = unsafe { sa.sin6_addr.u.Byte() };
                 // Ignore all fe80:: addresses as these are link locals
-                if sa.sin6_addr.s6_addr[0] == 0xfe && sa.sin6_addr.s6_addr[1] == 0x80 {
+                if s6_addr[0] == 0xfe && s6_addr[1] == 0x80 {
                     return None;
                 }
-                Some(IpAddr::V6(Ipv6Addr::from(sa.sin6_addr.s6_addr)))
+                Some(IpAddr::V6(Ipv6Addr::from(s6_addr.clone())))
             }
             None => None,
         }


### PR DESCRIPTION
These are just the easy pickings.

Missing/incorrect `use` statements, and some missing features in Cargo.toml

This still doesn't compile on windows: https://ci.appveyor.com/project/willstott101/if-addrs/builds/35244539