### PR TITLE
Support rust version 1.40.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -23,12 +23,13 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        rust: ["1.40.0", stable]
     steps:
       - uses: actions/checkout@v2
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal
-          toolchain: stable
+          toolchain: ${{ matrix.rust }}
           override: true
       - name: Build
         uses: actions-rs/cargo@v1

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -65,10 +65,10 @@ impl SockAddr {
                     return None;
                 }
                 Some(IpAddr::V4(Ipv4Addr::new(
-                    ((s_addr >> 0) & 255) as u8,
-                    ((s_addr >> 8) & 255) as u8,
-                    ((s_addr >> 16) & 255) as u8,
-                    ((s_addr >> 24) & 255) as u8,
+                    ((s_addr >> 0) & 255u32) as u8,
+                    ((s_addr >> 8) & 255u32) as u8,
+                    ((s_addr >> 16) & 255u32) as u8,
+                    ((s_addr >> 24) & 255u32) as u8,
                 )))
             }
             Some(SockAddrIn::In6(sa)) => {


### PR DESCRIPTION
By testing on Rust version 1.40.0 I can make sure this package is suitable for use within [librespot](https://github.com/librespot-org/librespot/issues/520#issuecomment-697328107).

Would you be willing to make 1.40.0 the minimum supported rust version for a while?