### PR TITLE
Add feature to optionally expose link-local IPv6 addresses

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,6 @@ features = [
     "Win32_Networking_WinSock",
     "Win32_NetworkManagement_IpHelper",
 ]
+
+[features]
+link-local = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -31,6 +31,11 @@ impl Interface {
         self.addr.is_loopback()
     }
 
+    /// Check whether this is a link local interface.
+    pub fn is_link_local(&self) -> bool {
+        self.addr.is_link_local()
+    }
+
     /// Get the IP address of this interface.
     pub fn ip(&self) -> IpAddr {
         self.addr.ip()
@@ -52,6 +57,14 @@ impl IfAddr {
         match *self {
             IfAddr::V4(ref ifv4_addr) => ifv4_addr.is_loopback(),
             IfAddr::V6(ref ifv6_addr) => ifv6_addr.is_loopback(),
+        }
+    }
+
+    /// Check whether this is a link local interface.
+    pub fn is_link_local(&self) -> bool {
+        match *self {
+            IfAddr::V4(ref ifv4_addr) => ifv4_addr.is_link_local(),
+            IfAddr::V6(ref ifv6_addr) => ifv6_addr.is_link_local(),
         }
     }
 
@@ -80,6 +93,11 @@ impl Ifv4Addr {
     pub fn is_loopback(&self) -> bool {
         self.ip.octets()[0] == 127
     }
+
+    /// Check whether this is a link local address.
+    pub fn is_link_local(&self) -> bool {
+        self.ip.is_link_local()
+    }
 }
 
 /// Details about the ipv6 address of an interface on this host.
@@ -97,6 +115,13 @@ impl Ifv6Addr {
     /// Check whether this is a loopback address.
     pub fn is_loopback(&self) -> bool {
         self.ip.segments() == [0, 0, 0, 0, 0, 0, 0, 1]
+    }
+
+    /// Check whether this is a link local address.
+    pub fn is_link_local(&self) -> bool {
+        let bytes = self.ip.octets();
+
+        bytes[0] == 0xfe && bytes[1] == 0x80
     }
 }
 

--- a/src/sockaddr.rs
+++ b/src/sockaddr.rs
@@ -44,6 +44,7 @@ impl SockAddr {
             }
             Some(SockAddrIn::In6(sa)) => {
                 // Ignore all fe80:: addresses as these are link locals
+                #[cfg(not(feature = "link-local"))]
                 if sa.sin6_addr.s6_addr[0] == 0xfe && sa.sin6_addr.s6_addr[1] == 0x80 {
                     return None;
                 }
@@ -59,6 +60,7 @@ impl SockAddr {
             Some(SockAddrIn::In(sa)) => {
                 let s_addr = unsafe { sa.sin_addr.S_un.S_addr };
                 // Ignore all 169.254.x.x addresses as these are not active interfaces
+                #[cfg(not(feature = "link-local"))]
                 if s_addr & 65535 == 0xfea9 {
                     return None;
                 }
@@ -68,6 +70,7 @@ impl SockAddr {
             Some(SockAddrIn::In6(sa)) => {
                 let s6_addr = unsafe { sa.sin6_addr.u.Byte };
                 // Ignore all fe80:: addresses as these are link locals
+                #[cfg(not(feature = "link-local"))]
                 if s6_addr[0] == 0xfe && s6_addr[1] == 0x80 {
                     return None;
                 }


### PR DESCRIPTION
This PR adds an optional feature, that is disabled by default, that allows developers get back the link-local addresses in the response. 