### PR TITLE
Windows get_if_addrs() filter out all addresses with dad not in preferred state

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,6 +183,7 @@ mod getifaddrs_windows {
     use crate::windows::IfAddrs;
     use std::io;
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
+    use windows_sys::Win32::Networking::WinSock::IpDadStatePreferred;
 
     /// Return a vector of IP details for all the valid interfaces on this host.
     pub fn get_if_addrs() -> io::Result<Vec<Interface>> {
@@ -191,6 +192,9 @@ mod getifaddrs_windows {
 
         for ifaddr in ifaddrs.iter() {
             for addr in ifaddr.unicast_addresses() {
+                if addr.dadstate != IpDadStatePreferred {
+                    continue;
+                }
                 let addr = match sockaddr::to_ipaddr(addr.address.lp_socket_address) {
                     None => continue,
                     Some(IpAddr::V4(ipv4_addr)) => {

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -10,6 +10,7 @@
 use libc::{self, c_char, c_int, c_ulong, c_void, size_t};
 use std::ffi::CStr;
 use std::{io, ptr};
+use windows_sys::Win32::Networking::WinSock::{NL_DAD_STATE, NL_PREFIX_ORIGIN, NL_SUFFIX_ORIGIN};
 use windows_sys::{Win32::Foundation::ERROR_SUCCESS, Win32::Networking::WinSock::SOCKADDR};
 
 type DWORD = c_ulong;
@@ -19,13 +20,21 @@ pub struct SocketAddress {
     pub lp_socket_address: *const SOCKADDR,
     pub i_socket_address_length: c_int,
 }
+
 #[repr(C)]
 pub struct IpAdapterUnicastAddress {
     pub length: c_ulong,
     pub flags: DWORD,
     pub next: *const IpAdapterUnicastAddress,
-    // Loads more follows, but I'm not bothering to map these for now
     pub address: SocketAddress,
+    pub prefixorigin: NL_PREFIX_ORIGIN,
+    pub suffixorigin: NL_SUFFIX_ORIGIN,
+    pub dadstate: NL_DAD_STATE,
+    // Loads more follows, but I'm not bothering to map these for now
+    // ULONG                                 ValidLifetime;
+    // ULONG                                 PreferredLifetime;
+    // ULONG                                 LeaseLifetime;
+    // UINT8                                 OnLinkPrefixLength;
 }
 #[repr(C)]
 pub struct IpAdapterPrefix {


### PR DESCRIPTION
On Windows do not retrieve addresses with DAD not in preferred state.
Please note that Chromium [works that way](https://chromium.googlesource.com/chromium/src/+/HEAD/net/base/network_interfaces_win.cc#173)
