### PR TITLE
Add apple tvos support

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -429,7 +429,7 @@ mod tests {
             .collect()
     }
 
-    #[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "ios"))]
+    #[cfg(any(target_os = "freebsd", target_os = "macos", target_os = "ios", target_os = "tvos"))]
     fn list_system_addrs() -> Vec<IpAddr> {
         list_system_interfaces("ifconfig", "")
             .lines()

--- a/src/posix.rs
+++ b/src/posix.rs
@@ -23,6 +23,7 @@ pub fn do_broadcast(ifaddr: &ifaddrs) -> Option<IpAddr> {
     target_os = "illumos",
     target_os = "ios",
     target_os = "macos",
+    target_os = "tvos",
     target_os = "openbsd",
     target_os = "netbsd"
 ))]


### PR DESCRIPTION
This PR allows using if-addrs lib to target [tier 3 *-apple builds](https://doc.rust-lang.org/nightly/rustc/platform-support/apple-tvos.html):

- Apple tvOS on aarch64
- Apple tvOS Simulator on x86_64