### PR TITLE
Use user-visible adapter name on Windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,6 +25,12 @@ pub struct Interface {
     pub addr: IfAddr,
     /// The index of the interface.
     pub index: Option<u32>,
+    /// (Windows only) A permanent and unique identifier for the interface. It
+    /// cannot be modified by the user. It is typically a GUID string of the
+    /// form: "{XXXXXXXX-XXXX-XXXX-XXXX-XXXXXXXXXXXX}", but this is not
+    /// guaranteed by the Windows API.
+    #[cfg(windows)]
+    pub adapter_name: String,
 }
 
 impl Interface {
@@ -345,6 +351,7 @@ mod getifaddrs_windows {
                     name: ifaddr.name(),
                     addr,
                     index,
+                    adapter_name: ifaddr.adapter_name(),
                 });
             }
         }


### PR DESCRIPTION
Closes #16

Keep the old GUID, but as its own field, as it's still useful in some contexts.
I would parse the GUID, but the WinAPI docs don't say anything about the string's format, so we can't trust that my system's values are formatted like anyone else.

Note: this is a **BREAKING CHANGE** if anyone was relying on the `name` struct member being the GUID. I think this is a good change to make, but if a release is pushed it'll need a semver bump.

Example interface after this change:
```rust
Interface {
    name: "Loopback Pseudo-Interface 1",
    addr: V4(
        Ifv4Addr {
            ip: 127.0.0.1,
            netmask: 255.0.0.0,
            broadcast: Some(
                127.255.255.255,
            ),
        },
    ),
    index: Some(
        1,
    ),
    adapter_name: "{E0EC89D8-2A3A-11EB-BA6E-806E6F6E6963}",
},
```