### PR TITLE
Add blocking "wait for network interface changes" API

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,7 +15,9 @@ libc = "0.2"
 version = "0.52.0"
 features = [
     "Win32_Foundation",
+    "Win32_System_IO",
     "Win32_System_Memory",
+    "Win32_System_Threading",
     "Win32_Networking_WinSock",
     "Win32_NetworkManagement_IpHelper",
     "Win32_NetworkManagement_Ndis",

--- a/examples/detect_interface_changes.rs
+++ b/examples/detect_interface_changes.rs
@@ -1,12 +1,3 @@
-// Copyright 2018 MaidSafe.net limited.
-//
-// This SAFE Network Software is licensed to you under the MIT license <LICENSE-MIT
-// http://opensource.org/licenses/MIT> or the Modified BSD license <LICENSE-BSD
-// https://opensource.org/licenses/BSD-3-Clause>, at your option. This file may not be copied,
-// modified, or distributed except according to those terms. Please review the Licences for the
-// specific language governing permissions and limitations relating to use of the SAFE Network
-// Software.
-
 //! Interface change notifier example.
 
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]

--- a/examples/detect_interface_changes.rs
+++ b/examples/detect_interface_changes.rs
@@ -7,10 +7,13 @@
 // specific language governing permissions and limitations relating to use of the SAFE Network
 // Software.
 
-//! List interface example.
+//! Interface change notifier example.
 
 fn main() {
-    let ifaces = if_addrs::get_if_addrs().unwrap();
-    println!("Got list of interfaces");
-    println!("{:#?}", ifaces);
+    println!("Waiting for interface changes...");
+    loop {
+        if if_addrs::detect_interface_changes(None).is_ok() {
+            println!("Network interfaces changed");
+        }
+    }
 }

--- a/examples/detect_interface_changes.rs
+++ b/examples/detect_interface_changes.rs
@@ -9,6 +9,7 @@
 
 //! Interface change notifier example.
 
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
 fn main() {
     println!("Waiting for interface changes...");
     loop {
@@ -16,4 +17,9 @@ fn main() {
             println!("Network interfaces changed");
         }
     }
+}
+
+#[cfg(any(target_os = "macos", target_os = "ios"))]
+fn main() {
+    println!("Interface change API is not implemented for macOS or iOS");
 }

--- a/examples/detect_interface_changes.rs
+++ b/examples/detect_interface_changes.rs
@@ -11,15 +11,16 @@
 
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]
 fn main() {
+    let mut if_change_notifier = if_addrs::IfChangeNotifier::new().unwrap();
     println!("Waiting for interface changes...");
     loop {
-        if if_addrs::detect_interface_changes(None).is_ok() {
-            println!("Network interfaces changed");
+        if let Ok(details) = if_change_notifier.wait(None) {
+            println!("Network interfaces changed: {:#?}", details);
         }
     }
 }
 
 #[cfg(any(target_os = "macos", target_os = "ios"))]
 fn main() {
-    println!("Interface change API is not implemented for macOS or iOS");
+    panic!("Interface change API is not implemented for macOS or iOS");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -384,6 +384,11 @@ pub fn get_if_addrs() -> io::Result<Vec<Interface>> {
     getifaddrs_windows::get_if_addrs()
 }
 
+#[cfg(windows)]
+pub use windows::detect_interface_changes;
+#[cfg(not(windows))]
+pub use posix::detect_interface_changes;
+
 #[cfg(test)]
 mod tests {
     use super::{get_if_addrs, Interface};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,8 +17,6 @@ mod windows;
 
 use std::io;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
-use std::time::Duration;
 
 /// Details about an interface on this host.
 #[derive(Debug, PartialEq, Eq, Hash, Clone)]
@@ -182,7 +180,7 @@ mod getifaddrs_posix {
                     IfAddr::V4(Ifv4Addr {
                         ip: ipv4_addr,
                         netmask,
-                        prefixlen: prefixlen,
+                        prefixlen,
                         broadcast,
                     })
                 }
@@ -207,7 +205,7 @@ mod getifaddrs_posix {
                     IfAddr::V6(Ifv6Addr {
                         ip: ipv6_addr,
                         netmask,
-                        prefixlen: prefixlen,
+                        prefixlen,
                         broadcast,
                     })
                 }
@@ -388,21 +386,86 @@ pub fn get_if_addrs() -> io::Result<Vec<Interface>> {
     getifaddrs_windows::get_if_addrs()
 }
 
-/// (Not available on iOS/macOS) Block until the OS reports that the network
-/// interface list has changed, or until an optional timeout.
-///
-/// For example, if an ethernet connector is plugged/unplugged, or a WiFi
-/// network is connected to.
-///
-/// Returns an [`io::ErrorKind::WouldBlock`] error on timeout, or another error
-/// if the network notifier could not be set up.
 #[cfg(not(any(target_os = "macos", target_os = "ios")))]
-pub fn detect_interface_changes(timeout: Option<Duration>) -> io::Result<()> {
+mod if_change_notifier {
+    use super::Interface;
+    use std::collections::HashSet;
+    use std::io;
+    use std::time::{Duration, Instant};
+
+    #[derive(Debug, PartialEq, Eq, Hash, Clone)]
+    pub enum IfChangeType {
+        Added(Interface),
+        Removed(Interface),
+    }
+
     #[cfg(windows)]
-    return windows::detect_interface_changes(timeout);
+    type InternalIfChangeNotifier = crate::windows::WindowsIfChangeNotifier;
     #[cfg(not(windows))]
-    return posix_not_mac::detect_interface_changes(timeout);
+    type InternalIfChangeNotifier = crate::posix_not_mac::PosixIfChangeNotifier;
+
+    /// (Not available on iOS/macOS) A utility to monitor for interface changes
+    /// and report them, so you can handle events such as WiFi
+    /// disconnection/flight mode/route changes
+    pub struct IfChangeNotifier {
+        inner: InternalIfChangeNotifier,
+        last_ifs: HashSet<Interface>,
+    }
+
+    impl IfChangeNotifier {
+        /// Create a new interface change notifier Returns an
+        /// [`io::ErrorKind::WouldBlock`] error if the network notifier could
+        /// not be set up.
+        pub fn new() -> io::Result<Self> {
+            Ok(Self {
+                inner: InternalIfChangeNotifier::new()?,
+                last_ifs: HashSet::from_iter(super::get_if_addrs()?),
+            })
+        }
+
+        /// (Not available on iOS/macOS) Block until the OS reports that the
+        /// network interface list has changed, or until an optional timeout.
+        ///
+        /// For example, if an ethernet connector is plugged/unplugged, or a
+        /// WiFi network is connected to.
+        ///
+        /// The changed interfaces are returned. If an interface has both IPv4
+        /// and IPv6 addresses, you can expect both of them to be returned from
+        /// a single call to `wait`.
+        ///
+        /// Returns an [`io::ErrorKind::WouldBlock`] error on timeout, or
+        /// another error if the network notifier could not be read from.
+        pub fn wait(&mut self, timeout: Option<Duration>) -> io::Result<Vec<IfChangeType>> {
+            let start = Instant::now();
+            loop {
+                self.inner
+                    .wait(timeout.map(|t| t.saturating_sub(start.elapsed())))?;
+
+                // something has changed - now we find out what (or whether it was spurious)
+                let new_ifs = HashSet::from_iter(super::get_if_addrs()?);
+                let mut changes: Vec<IfChangeType> = new_ifs
+                    .difference(&self.last_ifs)
+                    .cloned()
+                    .map(IfChangeType::Added)
+                    .collect();
+                changes.extend(
+                    self.last_ifs
+                        .difference(&new_ifs)
+                        .cloned()
+                        .map(IfChangeType::Removed),
+                );
+                self.last_ifs = new_ifs;
+
+                if !changes.is_empty() {
+                    return Ok(changes);
+                }
+            }
+        }
+    }
 }
+
+#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+pub use if_change_notifier::{IfChangeNotifier, IfChangeType};
 
 #[cfg(test)]
 mod tests {
@@ -422,7 +485,7 @@ mod tests {
         };
         let mut process = match start_cmd {
             Err(why) => {
-                println!("couldn't start cmd {} : {}", cmd, why.to_string());
+                println!("couldn't start cmd {} : {}", cmd, why);
                 return "".to_string();
             }
             Ok(process) => process,
@@ -533,5 +596,24 @@ mod tests {
             }
             assert!(listed);
         }
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "ios")))]
+    #[test]
+    fn test_if_notifier() {
+        // Check that the interface notifier can start up and time out. No easy
+        // way to programmatically add/remove interfaces, so set a timeout of 0.
+        // Will cover a potential case of inadequate setup leading to an
+        // immediate change notification.
+        //
+        // There is a small race condition from creation -> check that an
+        // interface change *actually* occurs, so this test may spuriously fail
+        // extremely rarely.
+
+        let notifier = crate::IfChangeNotifier::new();
+        assert!(notifier.is_ok());
+        let mut notifier = notifier.unwrap();
+
+        assert!(notifier.wait(Some(Duration::ZERO)).is_err());
     }
 }

--- a/src/posix.rs
+++ b/src/posix.rs
@@ -8,8 +8,12 @@
 // Software.
 
 use crate::sockaddr;
-use libc::{freeifaddrs, getifaddrs, ifaddrs};
-use std::net::IpAddr;
+use libc::{
+    bind, close, freeifaddrs, getifaddrs, ifaddrs, sockaddr_nl, socket, AF_NETLINK, NETLINK_ROUTE, SOCK_RAW
+};
+use std::net::{IpAddr, UdpSocket};
+use std::os::fd::FromRawFd;
+use std::time::Duration;
 use std::{io, mem};
 
 pub fn do_broadcast(ifaddr: &ifaddrs) -> Option<IpAddr> {
@@ -93,4 +97,40 @@ impl Iterator for IfAddrsIterator {
             result
         })
     }
+}
+
+/// Block until the OS reports that the network interface list has changed, or
+/// until an optional timeout. Returns an [`io::ErrorKind::WouldBlock`] error on
+/// timeout, or another error if the network notifier could not be set up.
+pub fn detect_interface_changes(timeout: Option<Duration>) -> io::Result<()> {
+    let socket = unsafe { socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE) };
+    if socket < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let mut sockaddr: sockaddr_nl = unsafe { mem::zeroed() };
+    sockaddr.nl_family = AF_NETLINK as u16;
+    sockaddr.nl_groups = 1; // RTNLGRP_LINK
+
+    if unsafe {
+        bind(
+            socket,
+            &sockaddr as *const _ as *const libc::sockaddr,
+            mem::size_of::<sockaddr_nl>() as libc::socklen_t,
+        )
+    } < 0
+    {
+        unsafe { close(socket) };
+        return Err(io::Error::last_os_error());
+    }
+
+    // lie about the type, since they all use fds and we don't need specifics
+    // after we have called bind
+    let socket = unsafe { UdpSocket::from_raw_fd(socket) };
+
+    let mut buf = [0u8; 65536];
+    socket.set_read_timeout(timeout)?;
+    socket.recv(&mut buf)?;
+
+    Ok(())
 }

--- a/src/posix_not_mac.rs
+++ b/src/posix_not_mac.rs
@@ -1,39 +1,85 @@
+use std::io;
 use std::mem;
-use std::net::UdpSocket;
 use std::time::Duration;
-use std::{io, os::fd::FromRawFd};
 
-use libc::{bind, close, sockaddr_nl, socket, AF_NETLINK, NETLINK_ROUTE, SOCK_RAW};
+use libc::{
+    bind, c_int, c_void, close, recv, setsockopt, sockaddr_nl, socket, socklen_t, ssize_t, timeval,
+    AF_NETLINK, NETLINK_ROUTE, SOCK_RAW, SOL_SOCKET, SO_RCVTIMEO,
+};
+
+#[repr(transparent)]
+struct NetlinkSocket(c_int);
+
+impl NetlinkSocket {
+    fn new() -> io::Result<Self> {
+        Ok(NetlinkSocket(check_io(unsafe {
+            socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE)
+        })?))
+    }
+}
+
+impl Drop for NetlinkSocket {
+    fn drop(&mut self) {
+        unsafe { close(self.0) };
+    }
+}
+
+fn check_io(res: c_int) -> io::Result<c_int> {
+    if res < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(res)
+    }
+}
+
+fn check_recv(res: ssize_t) -> io::Result<ssize_t> {
+    if res < 0 {
+        Err(io::Error::last_os_error())
+    } else {
+        Ok(res)
+    }
+}
 
 pub fn detect_interface_changes(timeout: Option<Duration>) -> io::Result<()> {
-    let socket = unsafe { socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE) };
-    if socket < 0 {
-        return Err(io::Error::last_os_error());
-    }
+    let socket = NetlinkSocket::new()?;
 
     let mut sockaddr: sockaddr_nl = unsafe { mem::zeroed() };
     sockaddr.nl_family = AF_NETLINK as u16;
     sockaddr.nl_groups = 1; // RTNLGRP_LINK
 
-    if unsafe {
+    check_io(unsafe {
         bind(
-            socket,
+            socket.0,
             &sockaddr as *const _ as *const libc::sockaddr,
             mem::size_of::<sockaddr_nl>() as libc::socklen_t,
         )
-    } < 0
-    {
-        unsafe { close(socket) };
-        return Err(io::Error::last_os_error());
+    })?;
+
+    // TODO: When MSRV moves beyond Rust 1.66, this can be cleaner as
+    // let mut socket = UdpSocket::from_raw_fd(socket);
+    // socket.set_read_timeout(timeout)?;
+    // socket.recv(&mut buf)?;
+
+    if let Some(timeout) = timeout {
+        let t = timeval {
+            tv_sec: timeout.as_secs().try_into().expect("timeout overflow"),
+            tv_usec: timeout
+                .subsec_micros()
+                .try_into()
+                .expect("timeout overflow"),
+        };
+        check_io(unsafe {
+            setsockopt(
+                socket.0,
+                SOL_SOCKET,
+                SO_RCVTIMEO,
+                core::ptr::addr_of!(t) as *const _,
+                mem::size_of::<timeval>() as socklen_t,
+            )
+        })?;
     }
-
-    // lie about the type, since they all use fds and we don't need specifics
-    // after we have called bind
-    let socket = unsafe { UdpSocket::from_raw_fd(socket) };
-
     let mut buf = [0u8; 65536];
-    socket.set_read_timeout(timeout)?;
-    socket.recv(&mut buf)?;
+    check_recv(unsafe { recv(socket.0, buf.as_mut_ptr() as *mut c_void, buf.len(), 0) })?;
 
     Ok(())
 }

--- a/src/posix_not_mac.rs
+++ b/src/posix_not_mac.rs
@@ -40,46 +40,65 @@ fn check_recv(res: ssize_t) -> io::Result<ssize_t> {
     }
 }
 
-pub fn detect_interface_changes(timeout: Option<Duration>) -> io::Result<()> {
-    let socket = NetlinkSocket::new()?;
+pub struct PosixIfChangeNotifier {
+    socket: NetlinkSocket,
+}
 
-    let mut sockaddr: sockaddr_nl = unsafe { mem::zeroed() };
-    sockaddr.nl_family = AF_NETLINK as u16;
-    sockaddr.nl_groups = 1; // RTNLGRP_LINK
+impl PosixIfChangeNotifier {
+    pub fn new() -> io::Result<Self> {
+        let socket = NetlinkSocket::new()?;
 
-    check_io(unsafe {
-        bind(
-            socket.0,
-            &sockaddr as *const _ as *const libc::sockaddr,
-            mem::size_of::<sockaddr_nl>() as libc::socklen_t,
-        )
-    })?;
+        let mut sockaddr: sockaddr_nl = unsafe { mem::zeroed() };
+        sockaddr.nl_family = AF_NETLINK as u16;
+        sockaddr.nl_groups = 1; // RTNLGRP_LINK
 
-    // TODO: When MSRV moves beyond Rust 1.66, this can be cleaner as
-    // let mut socket = UdpSocket::from_raw_fd(socket);
-    // socket.set_read_timeout(timeout)?;
-    // socket.recv(&mut buf)?;
+        check_io(unsafe {
+            bind(
+                socket.0,
+                &sockaddr as *const _ as *const libc::sockaddr,
+                mem::size_of::<sockaddr_nl>() as libc::socklen_t,
+            )
+        })?;
 
-    if let Some(timeout) = timeout {
-        let t = timeval {
-            tv_sec: timeout.as_secs().try_into().expect("timeout overflow"),
-            tv_usec: timeout
-                .subsec_micros()
-                .try_into()
-                .expect("timeout overflow"),
+        Ok(Self { socket })
+    }
+
+    pub fn wait(&self, timeout: Option<Duration>) -> io::Result<()> {
+        // TODO: When MSRV moves beyond Rust 1.66, this can be cleaner as
+        // let mut socket = UdpSocket::from_raw_fd(socket);
+        // socket.set_read_timeout(timeout)?;
+        // socket.recv(&mut buf)?;
+
+        let timeout = if let Some(timeout) = timeout {
+            let mut t = timeval {
+                tv_sec: timeout.as_secs().try_into().expect("timeout overflow"),
+                tv_usec: timeout.subsec_micros().into(),
+            };
+            // a timeout of 0 is infinity, so if the requested duration is too
+            // small, make it nonzero
+            if t.tv_sec == 0 && t.tv_usec == 0 {
+                t.tv_usec = 1;
+            }
+            t
+        } else {
+            timeval {
+                tv_sec: 0,
+                tv_usec: 0,
+            }
         };
+
         check_io(unsafe {
             setsockopt(
-                socket.0,
+                self.socket.0,
                 SOL_SOCKET,
                 SO_RCVTIMEO,
-                core::ptr::addr_of!(t) as *const _,
+                core::ptr::addr_of!(timeout) as *const _,
                 mem::size_of::<timeval>() as socklen_t,
             )
         })?;
-    }
-    let mut buf = [0u8; 65536];
-    check_recv(unsafe { recv(socket.0, buf.as_mut_ptr() as *mut c_void, buf.len(), 0) })?;
+        let mut buf = [0u8; 65536];
+        check_recv(unsafe { recv(self.socket.0, buf.as_mut_ptr() as *mut c_void, buf.len(), 0) })?;
 
-    Ok(())
+        Ok(())
+    }
 }

--- a/src/posix_not_mac.rs
+++ b/src/posix_not_mac.rs
@@ -1,0 +1,39 @@
+use std::mem;
+use std::net::UdpSocket;
+use std::time::Duration;
+use std::{io, os::fd::FromRawFd};
+
+use libc::{bind, close, sockaddr_nl, socket, AF_NETLINK, NETLINK_ROUTE, SOCK_RAW};
+
+pub fn detect_interface_changes(timeout: Option<Duration>) -> io::Result<()> {
+    let socket = unsafe { socket(AF_NETLINK, SOCK_RAW, NETLINK_ROUTE) };
+    if socket < 0 {
+        return Err(io::Error::last_os_error());
+    }
+
+    let mut sockaddr: sockaddr_nl = unsafe { mem::zeroed() };
+    sockaddr.nl_family = AF_NETLINK as u16;
+    sockaddr.nl_groups = 1; // RTNLGRP_LINK
+
+    if unsafe {
+        bind(
+            socket,
+            &sockaddr as *const _ as *const libc::sockaddr,
+            mem::size_of::<sockaddr_nl>() as libc::socklen_t,
+        )
+    } < 0
+    {
+        unsafe { close(socket) };
+        return Err(io::Error::last_os_error());
+    }
+
+    // lie about the type, since they all use fds and we don't need specifics
+    // after we have called bind
+    let socket = unsafe { UdpSocket::from_raw_fd(socket) };
+
+    let mut buf = [0u8; 65536];
+    socket.set_read_timeout(timeout)?;
+    socket.recv(&mut buf)?;
+
+    Ok(())
+}

--- a/src/windows.rs
+++ b/src/windows.rs
@@ -11,14 +11,17 @@ use std::ffi::CStr;
 use std::time::Duration;
 use std::{io, ptr};
 use windows_sys::Win32::Foundation::{
-    ERROR_BUFFER_OVERFLOW, ERROR_SUCCESS, HANDLE, NO_ERROR, WAIT_ABANDONED, WAIT_OBJECT_0, WAIT_TIMEOUT
+    ERROR_BUFFER_OVERFLOW, ERROR_SUCCESS, HANDLE, NO_ERROR, WAIT_ABANDONED, WAIT_OBJECT_0,
+    WAIT_TIMEOUT,
 };
 use windows_sys::Win32::NetworkManagement::IpHelper::{
     CancelIPChangeNotify, GetAdaptersAddresses, NotifyAddrChange, GAA_FLAG_INCLUDE_PREFIX,
     GAA_FLAG_SKIP_ANYCAST, GAA_FLAG_SKIP_DNS_SERVER, GAA_FLAG_SKIP_MULTICAST,
     IP_ADAPTER_ADDRESSES_LH, IP_ADAPTER_PREFIX_XP, IP_ADAPTER_UNICAST_ADDRESS_LH,
 };
-use windows_sys::Win32::Networking::WinSock::{WSACloseEvent, WSACreateEvent, WSAGetLastError, WSA_IO_PENDING};
+use windows_sys::Win32::Networking::WinSock::{
+    WSACloseEvent, WSACreateEvent, WSAGetLastError, WSA_IO_PENDING,
+};
 use windows_sys::Win32::System::Memory::{
     GetProcessHeap, HeapAlloc, HeapFree, HEAP_NONE, HEAP_ZERO_MEMORY,
 };
@@ -213,9 +216,6 @@ impl<'a> Iterator for UnicastAddressesIterator<'a> {
     }
 }
 
-/// Block until the OS reports that the network interface list has changed, or
-/// until an optional timeout. Returns an [`io::ErrorKind::WouldBlock`] error on
-/// timeout, or another error if the network notifier could not be set up.
 pub fn detect_interface_changes(timeout: Option<Duration>) -> io::Result<()> {
     let mut overlap: OVERLAPPED = unsafe { std::mem::zeroed() };
     let mut notify_event: HANDLE = Default::default();
@@ -239,7 +239,9 @@ pub fn detect_interface_changes(timeout: Option<Duration>) -> io::Result<()> {
 
     let ret = match unsafe { WaitForSingleObject(overlap.hEvent, millis) } {
         WAIT_OBJECT_0 => Ok(()),
-        WAIT_TIMEOUT | WAIT_ABANDONED => Err(io::Error::new(io::ErrorKind::WouldBlock, "Timed out")),
+        WAIT_TIMEOUT | WAIT_ABANDONED => {
+            Err(io::Error::new(io::ErrorKind::WouldBlock, "Timed out"))
+        }
         _ => Err(io::Error::last_os_error()),
     };
     unsafe {


### PR DESCRIPTION
Closes #35.

Has a timeout, so I think most use cases will get by with a check loop with a ~100ms timeout. However, I suspect there is a very narrow race condition possible in this approach while the notifier isn't active, a persistent struct might make more sense. Feedback appreciated.

Tested in Windows, as well as posix by adding/removing a dummy ethernet adapter in WSL2.

Not really sure if there's a good way to test inside CI.