### PR TITLE
Fix illumos

### DIFF
--- a/.github/workflows/Cross.yml
+++ b/.github/workflows/Cross.yml
@@ -15,6 +15,7 @@ jobs:
           - aarch64-linux-android
           - x86_64-unknown-freebsd
           - x86_64-unknown-netbsd
+          - x86_64-unknown-illumos
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable

--- a/examples/detect_interface_changes.rs
+++ b/examples/detect_interface_changes.rs
@@ -1,6 +1,6 @@
 //! Interface change notifier example.
 
-#[cfg(not(any(target_os = "macos", target_os = "ios")))]
+#[cfg(not(any(target_os = "macos", target_os = "ios", target_os = "illumos")))]
 fn main() {
     let mut if_change_notifier = if_addrs::IfChangeNotifier::new().unwrap();
     println!("Waiting for interface changes...");
@@ -11,7 +11,7 @@ fn main() {
     }
 }
 
-#[cfg(any(target_os = "macos", target_os = "ios"))]
+#[cfg(any(target_os = "macos", target_os = "ios", target_os = "illumos"))]
 fn main() {
     panic!("Interface change API is not implemented for macOS or iOS");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -25,7 +25,8 @@ mod posix;
     )),
     not(target_os = "freebsd"),
     not(target_os = "netbsd"),
-    not(target_os = "openbsd")
+    not(target_os = "openbsd"),
+    not(target_os = "illumos")
 ))]
 mod posix_not_apple;
 mod sockaddr;
@@ -426,7 +427,8 @@ pub fn get_if_addrs() -> io::Result<Vec<Interface>> {
     ),
     target_os = "freebsd",
     target_os = "netbsd",
-    target_os = "openbsd"
+    target_os = "openbsd",
+    target_os = "illumos"
 )))]
 #[cfg_attr(
     docsrs,
@@ -434,7 +436,8 @@ pub fn get_if_addrs() -> io::Result<Vec<Interface>> {
         not(target_vendor = "apple"),
         not(target_os = "freebsd"),
         not(target_os = "netbsd"),
-        not(target_os = "openbsd")
+        not(target_os = "openbsd"),
+        not(target_os = "illumos")
     )))
 )]
 mod if_change_notifier {
@@ -526,7 +529,8 @@ mod if_change_notifier {
     ),
     target_os = "freebsd",
     target_os = "netbsd",
-    target_os = "openbsd"
+    target_os = "openbsd",
+    target_os = "illumos"
 )))]
 #[cfg_attr(
     docsrs,
@@ -534,7 +538,8 @@ mod if_change_notifier {
         not(target_vendor = "apple"),
         not(target_os = "freebsd"),
         not(target_os = "netbsd"),
-        not(target_os = "openbsd")
+        not(target_os = "openbsd"),
+        not(target_os = "illumos")
     )))
 )]
 pub use if_change_notifier::{IfChangeNotifier, IfChangeType};
@@ -613,6 +618,7 @@ mod tests {
         target_os = "freebsd",
         target_os = "netbsd",
         target_os = "openbsd",
+        target_os = "illumos",
         all(
             target_vendor = "apple",
             any(
@@ -692,7 +698,8 @@ mod tests {
         ),
         target_os = "freebsd",
         target_os = "netbsd",
-        target_os = "openbsd"
+        target_os = "openbsd",
+        target_os = "illumos"
     )))]
     #[test]
     fn test_if_notifier() {


### PR DESCRIPTION
It looks like along the way some new changes broke if-addrs on illumos.  This gets us working again:

```
❯ cargo t
    Finished `test` profile [unoptimized + debuginfo] target(s) in 0.02s
     Running unittests src/lib.rs (target/debug/deps/if_addrs-6b7c907b040d5b20)

running 1 test
test tests::test_get_if_addrs ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 1.00s

   Doc-tests if_addrs

running 0 tests

test result: ok. 0 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
```

Would it be possible to also publish a new version once we are happy with this PR since I am trying to update another create which still depends on `get_if_addrs`? 