### PR TITLE
feat: add a new `oper_status` field in Interface

### DIFF
--- a/src/windows.rs
+++ b/src/windows.rs
@@ -24,8 +24,7 @@ use windows_sys::Win32::System::Memory::{
     GetProcessHeap, HeapAlloc, HeapFree, HEAP_NONE, HEAP_ZERO_MEMORY,
 };
 
-#[cfg(windows)]
-const WINDOWS_IF_OPER_STATUS_UP: i32 = 1;
+use crate::IfOperStatus;
 
 #[repr(transparent)]
 pub struct IpAdapterAddresses(*const IP_ADAPTER_ADDRESSES_LH);
@@ -79,8 +78,8 @@ impl IpAdapterAddresses {
         }
     }
 
-    pub fn is_up(&self) -> bool {
-        unsafe { (*self.0).OperStatus == WINDOWS_IF_OPER_STATUS_UP }
+    pub fn oper_status(&self) -> IfOperStatus {
+        unsafe { (*self.0).OperStatus.into() }
     }
 }
 


### PR DESCRIPTION
This patch is an attempt to resolve the issue #48. I think this lib already has a good foundation for checking the interface status. For my project, I'd prefer to use this lib instead of adding another dependency only for checking interface up or not. 

Technically this is a breaking change. However I think from the user point of view, there are no changes in most cases because they (mostly) don't construct `Interface`.  Let me know what you think. Thanks!
